### PR TITLE
must authorize to access details and favorites

### DIFF
--- a/RecipeWebsite/Controllers/RecipeController.cs
+++ b/RecipeWebsite/Controllers/RecipeController.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Ganss.Xss;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -34,6 +35,7 @@ namespace RecipeWebsite.Controllers
         }
 
         // GET: Recipe/Details/5
+        [Authorize]
         public async Task<IActionResult> Details(int? id)
         {
             if (id == null)
@@ -271,6 +273,7 @@ namespace RecipeWebsite.Controllers
         }
 
         //Get: FavoriteRecipes
+        [Authorize]
         public async Task<IActionResult> MyFavorites() {
 
             //gets logged in user 


### PR DESCRIPTION
resolves #101 

This fix redirects unauthorized users to the login page when trying to access details for a recipe or favorites